### PR TITLE
fix(JAQPOT-357): fix qsar models asking for s3

### DIFF
--- a/src/main/kotlin/org/jaqpot/api/service/model/ModelExtensions.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/model/ModelExtensions.kt
@@ -1,0 +1,10 @@
+package org.jaqpot.api.service.model
+
+import org.jaqpot.api.entity.Model
+import org.jaqpot.api.entity.ModelType
+
+fun Model.isQsarModel() = this.type in listOf(
+    ModelType.QSAR_TOOLBOX_CALCULATOR,
+    ModelType.QSAR_TOOLBOX_QSAR_MODEL,
+    ModelType.QSAR_TOOLBOX_PROFILER
+)

--- a/src/main/kotlin/org/jaqpot/api/service/model/ModelService.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/model/ModelService.kt
@@ -1,13 +1,13 @@
 package org.jaqpot.api.service.model
 
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.transaction.Transactional
 import org.jaqpot.api.ModelApiDelegate
 import org.jaqpot.api.cache.CacheKeys
 import org.jaqpot.api.entity.*
-import org.jaqpot.api.mapper.*
+import org.jaqpot.api.mapper.toDto
+import org.jaqpot.api.mapper.toEntity
+import org.jaqpot.api.mapper.toGetModels200ResponseDto
 import org.jaqpot.api.model.*
 import org.jaqpot.api.repository.DatasetRepository
 import org.jaqpot.api.repository.ModelRepository
@@ -215,16 +215,10 @@ class ModelService(
         model: Model,
         dataset: Dataset
     ): ResponseEntity<Unit> {
-        val rawModel = storageService.readRawModel(model)
-        val doaDtos = model.doas.map {
-            val rawDoaData = storageService.readRawDoa(it)
-            val type = object : TypeToken<Map<String, Any>>() {}.type
-            val doaData: Map<String, Any> = Gson().fromJson(rawDoaData.decodeToString(), type)
-            it.toPredictionDto(doaData)
-        }
+
 
         this.predictionService.executePredictionAndSaveResults(
-            model.toPredictionModelDto(rawModel, doaDtos),
+            model,
             dataset
         )
 

--- a/src/main/kotlin/org/jaqpot/api/service/model/ModelTypeExtensions.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/model/ModelTypeExtensions.kt
@@ -1,9 +1,0 @@
-package org.jaqpot.api.service.model
-
-import org.jaqpot.api.model.ModelTypeDto
-
-fun ModelTypeDto.isQsarModel() = this in listOf(
-    ModelTypeDto.QSAR_TOOLBOX_CALCULATOR,
-    ModelTypeDto.QSAR_TOOLBOX_QSAR_MODEL,
-    ModelTypeDto.QSAR_TOOLBOX_PROFILER
-)

--- a/src/main/kotlin/org/jaqpot/api/service/model/QSARToolboxPredictionService.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/model/QSARToolboxPredictionService.kt
@@ -1,8 +1,7 @@
 package org.jaqpot.api.service.model
 
-import org.jaqpot.api.dto.prediction.PredictionModelDto
+import org.jaqpot.api.entity.ModelType
 import org.jaqpot.api.model.DatasetDto
-import org.jaqpot.api.model.ModelTypeDto
 import org.jaqpot.api.service.qsartoolbox.QSARToolboxAPI
 import org.springframework.stereotype.Service
 
@@ -65,20 +64,19 @@ class QSARToolboxPredictionService(private val qsarToolboxAPI: QSARToolboxAPI) {
     }
 
     fun makePredictionRequest(
-        predictionModelDto: PredictionModelDto,
         datasetDto: DatasetDto,
-        type: ModelTypeDto
+        type: ModelType
     ): List<Any> {
         return when (type) {
-            ModelTypeDto.QSAR_TOOLBOX_CALCULATOR -> {
+            ModelType.QSAR_TOOLBOX_CALCULATOR -> {
                 makeCalculatorPredictionRequest(datasetDto)
             }
 
-            ModelTypeDto.QSAR_TOOLBOX_QSAR_MODEL -> {
+            ModelType.QSAR_TOOLBOX_QSAR_MODEL -> {
                 makeQsarModelPredictionRequest(datasetDto)
             }
 
-            ModelTypeDto.QSAR_TOOLBOX_PROFILER -> {
+            ModelType.QSAR_TOOLBOX_PROFILER -> {
                 makeProfilerPredictionRequest(datasetDto)
             }
 

--- a/src/main/kotlin/org/jaqpot/api/service/prediction/PredictionService.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/prediction/PredictionService.kt
@@ -1,18 +1,20 @@
 package org.jaqpot.api.service.prediction
 
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.jaqpot.api.dto.prediction.PredictionModelDto
 import org.jaqpot.api.entity.Dataset
 import org.jaqpot.api.entity.DatasetStatus
+import org.jaqpot.api.entity.Model
 import org.jaqpot.api.mapper.toDto
-import org.jaqpot.api.model.DatasetDto
+import org.jaqpot.api.mapper.toPredictionDto
+import org.jaqpot.api.mapper.toPredictionModelDto
 import org.jaqpot.api.repository.DatasetRepository
 import org.jaqpot.api.service.model.QSARToolboxPredictionService
 import org.jaqpot.api.service.model.dto.PredictionResponseDto
 import org.jaqpot.api.service.model.isQsarModel
 import org.jaqpot.api.service.prediction.runtime.PredictionChain
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
+import org.jaqpot.api.storage.StorageService
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import java.time.OffsetDateTime
@@ -22,6 +24,7 @@ import java.time.OffsetDateTime
 class PredictionService(
     private val datasetRepository: DatasetRepository,
     private val predictionChain: PredictionChain,
+    private val storageService: StorageService,
     private val qsarToolboxPredictionService: QSARToolboxPredictionService
 ) {
 
@@ -30,19 +33,12 @@ class PredictionService(
     }
 
     @Async
-    fun executePredictionAndSaveResults(predictionModelDto: PredictionModelDto, dataset: Dataset) {
-        val datasetDto = dataset.toDto()
-
-
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        headers.accept = listOf(MediaType.APPLICATION_JSON)
-
+    fun executePredictionAndSaveResults(model: Model, dataset: Dataset) {
 
         updateDatasetToExecuting(dataset)
 
         try {
-            val results: List<Any> = makePredictionRequest(predictionModelDto, datasetDto)
+            val results: List<Any> = makePredictionRequest(model, dataset)
             storeDatasetSuccess(dataset, results)
         } catch (e: Exception) {
             logger.error(e) { "Prediction for dataset with id ${dataset.id} failed" }
@@ -71,16 +67,25 @@ class PredictionService(
     }
 
     private fun makePredictionRequest(
-        predictionModelDto: PredictionModelDto,
-        datasetDto: DatasetDto
+        model: Model,
+        dataset: Dataset
     ): List<Any> {
-        if (predictionModelDto.type.isQsarModel()) {
+        val datasetDto = dataset.toDto()
+        if (model.isQsarModel()) {
             return qsarToolboxPredictionService.makePredictionRequest(
-                predictionModelDto,
                 datasetDto,
-                predictionModelDto.type
+                model.type
             )
         }
+
+        val rawModel = storageService.readRawModel(model)
+        val doaDtos = model.doas.map {
+            val rawDoaData = storageService.readRawDoa(it)
+            val type = object : TypeToken<Map<String, Any>>() {}.type
+            val doaData: Map<String, Any> = Gson().fromJson(rawDoaData.decodeToString(), type)
+            it.toPredictionDto(doaData)
+        }
+        val predictionModelDto = model.toPredictionModelDto(rawModel, doaDtos)
 
         val response: PredictionResponseDto =
             predictionChain.getPredictionResults(predictionModelDto, datasetDto)


### PR DESCRIPTION
qsartoolbox models were asking for the raw model from S3 but this does not make sense since there are no raw models for qsartoolbox, we directly access the API, so this fix will not request for raw models from s3 anymore for qsartoolbox models