### PR TITLE
fix(JAQPOT-357): fix qsar models asking for s3

### DIFF
--- a/src/main/kotlin/org/jaqpot/api/entity/Model.kt
+++ b/src/main/kotlin/org/jaqpot/api/entity/Model.kt
@@ -82,5 +82,11 @@ class Model(
     @Column(name = "legacy_additional_info", columnDefinition = "jsonb")
     val legacyAdditionalInfo: Map<String, Any>? = emptyMap(),
 
-    ) : BaseEntity()
+    ) : BaseEntity() {
+    fun isQsarToolboxModel() = this.type in listOf(
+        ModelType.QSAR_TOOLBOX_CALCULATOR,
+        ModelType.QSAR_TOOLBOX_QSAR_MODEL,
+        ModelType.QSAR_TOOLBOX_PROFILER
+    )
+}
 

--- a/src/main/kotlin/org/jaqpot/api/service/model/ModelService.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/model/ModelService.kt
@@ -215,7 +215,11 @@ class ModelService(
         model: Model,
         dataset: Dataset
     ): ResponseEntity<Unit> {
-        val rawModel = storageService.readRawModel(model)
+        val rawModel = if (model.isQsarToolboxModel()) {
+            byteArrayOf()
+        } else {
+            storageService.readRawModel(model)
+        }
         val doaDtos = model.doas.map {
             val rawDoaData = storageService.readRawDoa(it)
             val type = object : TypeToken<Map<String, Any>>() {}.type

--- a/src/main/kotlin/org/jaqpot/api/service/model/QSARToolboxPredictionService.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/model/QSARToolboxPredictionService.kt
@@ -16,7 +16,7 @@ class QSARToolboxPredictionService(private val qsarToolboxAPI: QSARToolboxAPI) {
         private const val PROFILER_GUID_KEY = "profilerGuid"
     }
 
-    private fun makeQsarModelPredictionRequest(datasetDto: DatasetDto): List<Any> {
+    private fun makeQsarModelPredictionRequest(datasetDto: DatasetDto): List<Map<*, *>> {
         return datasetDto.input.flatMapIndexed { index, it ->
             val datasetInput = it as DatasetInput
             val smiles = datasetInput[SMILES_KEY] as String
@@ -40,7 +40,7 @@ class QSARToolboxPredictionService(private val qsarToolboxAPI: QSARToolboxAPI) {
         }
     }
 
-    private fun makeCalculatorPredictionRequest(datasetDto: DatasetDto): List<Any> {
+    private fun makeCalculatorPredictionRequest(datasetDto: DatasetDto): List<Map<*, *>> {
         return datasetDto.input.flatMapIndexed { index, it ->
             val datasetInput = it as DatasetInput
             val smiles = datasetInput[SMILES_KEY] as String
@@ -64,33 +64,9 @@ class QSARToolboxPredictionService(private val qsarToolboxAPI: QSARToolboxAPI) {
         }
     }
 
-    fun makePredictionRequest(
-        predictionModelDto: PredictionModelDto,
-        datasetDto: DatasetDto,
-        type: ModelTypeDto
-    ): List<Any> {
-        return when (type) {
-            ModelTypeDto.QSAR_TOOLBOX_CALCULATOR -> {
-                makeCalculatorPredictionRequest(datasetDto)
-            }
-
-            ModelTypeDto.QSAR_TOOLBOX_QSAR_MODEL -> {
-                makeQsarModelPredictionRequest(datasetDto)
-            }
-
-            ModelTypeDto.QSAR_TOOLBOX_PROFILER -> {
-                makeProfilerPredictionRequest(datasetDto)
-            }
-
-            else -> {
-                throw IllegalArgumentException("Unsupported model type: $type")
-            }
-        }
-    }
-
     private fun makeProfilerPredictionRequest(
         datasetDto: DatasetDto
-    ): List<Any> {
+    ): List<Map<String, Any>> {
         return datasetDto.input.flatMapIndexed { index, it ->
             val datasetInput = it as DatasetInput
             val smiles = datasetInput[SMILES_KEY] as String
@@ -114,6 +90,30 @@ class QSARToolboxPredictionService(private val qsarToolboxAPI: QSARToolboxAPI) {
                         qsarProperties
                     }
 
+            }
+        }
+    }
+
+    fun makePredictionRequest(
+        predictionModelDto: PredictionModelDto,
+        datasetDto: DatasetDto,
+        type: ModelTypeDto
+    ): List<Map<*, *>> {
+        return when (type) {
+            ModelTypeDto.QSAR_TOOLBOX_CALCULATOR -> {
+                makeCalculatorPredictionRequest(datasetDto)
+            }
+
+            ModelTypeDto.QSAR_TOOLBOX_QSAR_MODEL -> {
+                makeQsarModelPredictionRequest(datasetDto)
+            }
+
+            ModelTypeDto.QSAR_TOOLBOX_PROFILER -> {
+                makeProfilerPredictionRequest(datasetDto)
+            }
+
+            else -> {
+                throw IllegalArgumentException("Unsupported model type: $type")
             }
         }
     }

--- a/src/main/kotlin/org/jaqpot/api/service/prediction/PredictionService.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/prediction/PredictionService.kt
@@ -9,10 +9,7 @@ import org.jaqpot.api.model.DatasetDto
 import org.jaqpot.api.repository.DatasetRepository
 import org.jaqpot.api.service.model.QSARToolboxPredictionService
 import org.jaqpot.api.service.model.dto.PredictionResponseDto
-import org.jaqpot.api.service.model.isQsarModel
 import org.jaqpot.api.service.prediction.runtime.PredictionChain
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import java.time.OffsetDateTime
@@ -32,12 +29,6 @@ class PredictionService(
     @Async
     fun executePredictionAndSaveResults(predictionModelDto: PredictionModelDto, dataset: Dataset) {
         val datasetDto = dataset.toDto()
-
-
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        headers.accept = listOf(MediaType.APPLICATION_JSON)
-
 
         updateDatasetToExecuting(dataset)
 
@@ -74,18 +65,10 @@ class PredictionService(
         predictionModelDto: PredictionModelDto,
         datasetDto: DatasetDto
     ): List<Any> {
-        if (predictionModelDto.type.isQsarModel()) {
-            return qsarToolboxPredictionService.makePredictionRequest(
-                predictionModelDto,
-                datasetDto,
-                predictionModelDto.type
-            )
-        }
-
         val response: PredictionResponseDto =
             predictionChain.getPredictionResults(predictionModelDto, datasetDto)
 
-        val results: List<Any> = response.predictions ?: emptyList()
+        val results: List<Any> = response.predictions
         return results
     }
 }


### PR DESCRIPTION
qsartoolbox models were asking for the raw model from S3 but this does not make sense since there are no raw models for qsartoolbox, we directly access the API, so this fix will not request for raw models from s3 anymore for qsartoolbox models