### PR TITLE
fix: dataset result query only when needed

### DIFF
--- a/src/main/kotlin/org/jaqpot/api/entity/Dataset.kt
+++ b/src/main/kotlin/org/jaqpot/api/entity/Dataset.kt
@@ -47,4 +47,10 @@ class Dataset(
     var executedAt: OffsetDateTime? = null,
 
     var executionFinishedAt: OffsetDateTime? = null
-) : BaseEntity()
+) : BaseEntity() {
+    fun shouldHaveResult(): Boolean {
+        return this.type == DatasetType.PREDICTION && this.status == DatasetStatus.SUCCESS
+    }
+}
+
+


### PR DESCRIPTION
We should query the s3 dataset bucket for results only when the dataset status is success