### PR TITLE
fix: prevent dataset offloading from silently stalling on async pool saturation

### DIFF
--- a/src/main/kotlin/org/jaqpot/api/config/AsyncConfig.kt
+++ b/src/main/kotlin/org/jaqpot/api/config/AsyncConfig.kt
@@ -1,0 +1,69 @@
+package org.jaqpot.api.config
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.AsyncConfigurer
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+import java.util.concurrent.ThreadPoolExecutor
+
+/**
+ * Configures the executor backing every `@Async` method (most importantly the dataset/prediction
+ * offloading in [org.jaqpot.api.service.prediction.rest.RESTPredictionService]).
+ *
+ * Spring Boot's default async executor uses an **unbounded** task queue. When the worker threads
+ * stall (e.g. a downstream call hangs), offload tasks pile up in that queue silently and forever:
+ * the dataset row keeps its input in Postgres, nothing is written to S3, and no error is ever
+ * logged. To make such a situation self-correcting and observable we:
+ *
+ *  - bound the queue and apply [ThreadPoolExecutor.CallerRunsPolicy] so that, once saturated, the
+ *    submitting thread runs the task itself (backpressure) instead of the work being lost;
+ *  - drain in-flight tasks on shutdown so offloads are not dropped during a deploy/restart;
+ *  - log any exception thrown from a void/`Unit`-returning `@Async` method, which Spring would
+ *    otherwise swallow.
+ *
+ * The bean is intentionally named `applicationTaskExecutor` so that Spring Boot's auto-configured
+ * executor backs off and Micrometer auto-instruments it (queue size, active threads, etc.).
+ */
+@Configuration
+class AsyncConfig : AsyncConfigurer {
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+
+        private const val CORE_POOL_SIZE = 8
+        private const val MAX_POOL_SIZE = 16
+        private const val QUEUE_CAPACITY = 100
+        private const val AWAIT_TERMINATION_SECONDS = 60
+    }
+
+    @Bean(name = ["applicationTaskExecutor", "taskExecutor"])
+    fun applicationTaskExecutor(): ThreadPoolTaskExecutor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = CORE_POOL_SIZE
+        executor.maxPoolSize = MAX_POOL_SIZE
+        executor.queueCapacity = QUEUE_CAPACITY
+        executor.setThreadNamePrefix("jaqpot-async-")
+        // Backpressure instead of silent task loss when the pool and queue are full.
+        executor.setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
+        // Drain queued/in-flight offloads on shutdown rather than dropping them.
+        executor.setWaitForTasksToCompleteOnShutdown(true)
+        executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS)
+        return executor
+    }
+
+    override fun getAsyncExecutor(): Executor {
+        return applicationTaskExecutor()
+    }
+
+    override fun getAsyncUncaughtExceptionHandler(): AsyncUncaughtExceptionHandler {
+        return AsyncUncaughtExceptionHandler { throwable, method, params ->
+            logger.error(throwable) {
+                "Uncaught exception in @Async method ${method.declaringClass.simpleName}.${method.name} " +
+                    "with ${params.size} argument(s)"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/jaqpot/api/config/RestTemplateConfig.kt
+++ b/src/main/kotlin/org/jaqpot/api/config/RestTemplateConfig.kt
@@ -1,0 +1,32 @@
+package org.jaqpot.api.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestTemplate
+import java.time.Duration
+
+/**
+ * Provides a [RestTemplate] with bounded connect/read timeouts.
+ *
+ * A bare `RestTemplate()` uses infinite connect and read timeouts. When a downstream service
+ * (e.g. the QSAR Toolbox backend) accepts a connection but never responds, the calling thread
+ * blocks forever. Because prediction requests run on the shared `@Async` pool, a handful of such
+ * hung calls permanently saturate the pool and silently stall all dataset offloading.
+ */
+@Configuration
+class RestTemplateConfig {
+
+    companion object {
+        private val CONNECT_TIMEOUT: Duration = Duration.ofSeconds(10)
+        private val READ_TIMEOUT: Duration = Duration.ofSeconds(60)
+    }
+
+    @Bean
+    fun restTemplate(): RestTemplate {
+        val factory = SimpleClientHttpRequestFactory()
+        factory.setConnectTimeout(CONNECT_TIMEOUT)
+        factory.setReadTimeout(READ_TIMEOUT)
+        return RestTemplate(factory)
+    }
+}

--- a/src/main/kotlin/org/jaqpot/api/repository/DatasetRepository.kt
+++ b/src/main/kotlin/org/jaqpot/api/repository/DatasetRepository.kt
@@ -20,6 +20,15 @@ interface DatasetRepository : CrudRepository<Dataset, Long> {
 
     fun findByIdAndModelId(id: Long, modelId: Long): Optional<Dataset>
 
+    /**
+     * Datasets whose input is still stored in the database (i.e. never offloaded to object storage)
+     * and that are older than [cutoff]. The model association is fetched eagerly so the results can
+     * be offloaded outside of a transaction. Used by the reconciliation job to recover datasets whose
+     * asynchronous offload never completed.
+     */
+    @Query("SELECT d FROM Dataset d JOIN FETCH d.model WHERE d.input IS NOT NULL AND d.createdAt < :cutoff")
+    fun findDatasetsWithInputNotOffloaded(@Param("cutoff") cutoff: OffsetDateTime, pageable: Pageable): List<Dataset>
+
     @Modifying
     @Transactional
     @Query("UPDATE Dataset d SET d.input = NULL, d.result = NULL WHERE d.id = :id")

--- a/src/main/kotlin/org/jaqpot/api/service/authentication/keycloak/KeycloakTokenExchanger.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/authentication/keycloak/KeycloakTokenExchanger.kt
@@ -12,14 +12,15 @@ import org.springframework.web.client.RestTemplate
 
 
 @Component
-class KeycloakTokenExchanger(private val keycloakConfig: KeycloakConfig) {
+class KeycloakTokenExchanger(
+    private val keycloakConfig: KeycloakConfig,
+    private val restTemplate: RestTemplate
+) {
     /**
      * Exchange a user token for an impersonation token
      * @see <a href="https://www.keycloak.org/docs/24.0.3/securing_apps/index.html#direct-naked-impersonation">https://www.keycloak.org/docs/24.0.3/securing_apps/index.html#direct-naked-impersonation</a>
      */
     fun exchangeToken(userId: String): String {
-        val restTemplate = RestTemplate()
-
         // Set headers
         val headers = HttpHeaders()
         headers.contentType = MediaType.APPLICATION_FORM_URLENCODED

--- a/src/main/kotlin/org/jaqpot/api/service/dataset/DatasetService.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/dataset/DatasetService.kt
@@ -22,6 +22,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.stereotype.Service
 import java.time.OffsetDateTime
+import java.util.concurrent.TimeUnit
 
 @Service
 class DatasetService(
@@ -32,6 +33,13 @@ class DatasetService(
 ) : DatasetApiDelegate {
     companion object {
         const val DATASET_EXPIRATION_DAYS = 30L
+        private const val RECONCILE_BATCH_SIZE = 200
+
+        /**
+         * Datasets younger than this are skipped by reconciliation so we never race with an
+         * asynchronous offload that is still legitimately in flight.
+         */
+        private const val RECONCILE_MIN_AGE_MINUTES = 15L
         private val logger = KotlinLogging.logger {}
     }
 
@@ -106,5 +114,53 @@ class DatasetService(
         datasetRepository.deleteAllById(expiredDatasets.mapNotNull { it.id })
 
         logger.info { "Purged ${expiredDatasets.size} expired datasets" }
+    }
+
+    /**
+     * Recovers datasets whose input was persisted to the database but never offloaded to object
+     * storage (e.g. because the asynchronous offload was dropped while the worker pool was saturated).
+     * For each such dataset it stores the raw input/result in object storage and, on success, clears
+     * the database copy — mirroring the offload performed on the prediction path.
+     *
+     * Intentionally not `@Transactional`: the object-storage I/O must not hold a database transaction
+     * open, and [DatasetRepository.setDatasetInputAndResultToNull] runs in its own transaction.
+     */
+    @Scheduled(fixedDelay = 5, initialDelay = 2, timeUnit = TimeUnit.MINUTES)
+    fun reconcileNonOffloadedDatasets() {
+        val cutoff = OffsetDateTime.now().minusMinutes(RECONCILE_MIN_AGE_MINUTES)
+        val datasets = datasetRepository.findDatasetsWithInputNotOffloaded(
+            cutoff,
+            PageRequest.of(0, RECONCILE_BATCH_SIZE, Sort.by("id").ascending())
+        )
+
+        if (datasets.isEmpty()) {
+            return
+        }
+
+        logger.warn {
+            "Reconciliation found ${datasets.size} dataset(s) with input not offloaded to storage " +
+                "(older than $RECONCILE_MIN_AGE_MINUTES minutes); attempting to offload them now"
+        }
+
+        var offloaded = 0
+        var failed = 0
+        for (dataset in datasets) {
+            try {
+                if (storageService.storeRawDataset(dataset)) {
+                    datasetRepository.setDatasetInputAndResultToNull(dataset.id)
+                    offloaded++
+                } else {
+                    failed++
+                }
+            } catch (e: Exception) {
+                failed++
+                logger.error(e) { "Failed to reconcile dataset ${dataset.id}" }
+            }
+        }
+
+        logger.warn {
+            "Reconciliation finished: offloaded $offloaded dataset(s), $failed failure(s) " +
+                "out of ${datasets.size} candidate(s)"
+        }
     }
 }

--- a/src/main/kotlin/org/jaqpot/api/service/qsartoolbox/QSARToolboxAPI.kt
+++ b/src/main/kotlin/org/jaqpot/api/service/qsartoolbox/QSARToolboxAPI.kt
@@ -10,7 +10,10 @@ import org.springframework.web.client.RestTemplate
 
 
 @Component
-class QSARToolboxAPI(private val qsartoolboxConfig: QsartoolboxConfig) {
+class QSARToolboxAPI(
+    private val qsartoolboxConfig: QsartoolboxConfig,
+    private val restTemplate: RestTemplate
+) {
 
     companion object {
         private val logger = KotlinLogging.logger {}
@@ -22,7 +25,6 @@ class QSARToolboxAPI(private val qsartoolboxConfig: QsartoolboxConfig) {
 
         val url = "${qsartoolboxConfig.url}/api/v6/search/smiles/${registerUnknown}/${ignoreStereo}?smiles={smiles}"
 
-        val restTemplate = RestTemplate()
         val response = restTemplate.getForEntity(url, Array<QSARSearchSmilesResponse>::class.java, smiles)
 
         return response.body
@@ -34,7 +36,6 @@ class QSARToolboxAPI(private val qsartoolboxConfig: QsartoolboxConfig) {
     ): Map<*, *>? {
         val url = "${qsartoolboxConfig.url}/api/v6/qsar/apply/${qsarGuid}/${chemId}"
 
-        val restTemplate = RestTemplate()
         val response = restTemplate.getForEntity(url, Map::class.java)
 
         return response.body
@@ -46,7 +47,6 @@ class QSARToolboxAPI(private val qsartoolboxConfig: QsartoolboxConfig) {
     ): List<String>? {
         val url = "${qsartoolboxConfig.url}/api/v6/profiling/${profilerGuid}/${chemId}"
 
-        val restTemplate = RestTemplate()
         val response =
             restTemplate.exchange(
                 url,
@@ -65,7 +65,6 @@ class QSARToolboxAPI(private val qsartoolboxConfig: QsartoolboxConfig) {
     ): Map<*, *>? {
         val url = "${qsartoolboxConfig.url}/api/v6/calculation/${calculatorId}/${chemId}"
 
-        val restTemplate = RestTemplate()
         val response = restTemplate.getForEntity(url, Map::class.java)
 
         return response.body

--- a/src/main/kotlin/org/jaqpot/api/storage/StorageService.kt
+++ b/src/main/kotlin/org/jaqpot/api/storage/StorageService.kt
@@ -53,55 +53,118 @@ class StorageService(
                 )
             }
 
+            logger.info {
+                "Offloaded dataset ${dataset.id} to storage bucket '${awsS3Config.datasetsBucketName}' " +
+                    "(result offloaded: ${dataset.result != null})"
+            }
             return true
         } catch (e: Exception) {
-            logger.error(e) { "Failed to store dataset with id ${dataset.id}" }
+            logger.error(e) {
+                "Failed to store dataset with id ${dataset.id} to bucket '${awsS3Config.datasetsBucketName}'"
+            }
             return false
         }
     }
 
     fun readRawDatasetInputs(datasets: List<Dataset>): Map<String, List<Any>> {
-        var rawDatasetsFromStorage = mutableMapOf<String, ByteArray>()
-        try {
-            rawDatasetsFromStorage =
-                this.storage.getObjects(awsS3Config.datasetsBucketName, datasets.map { "${it.id.toString()}/input" })
-                    .mapKeys { it.key.substringBefore("/") }.toMutableMap()
-        } catch (e: Exception) {
-            logger.warn(e) { "Failed to read datasets" }
+        val rawDatasetsFromStorage = readRawObjectsFromStorage(datasets, "input")
+
+        val servedFromDb = mutableListOf<String>()
+        val missing = mutableListOf<String>()
+
+        val inputs = datasets.associateTo(LinkedHashMap<String, List<Any>>()) { dataset ->
+            val key = dataset.id.toString()
+            val fromStorage = rawDatasetsFromStorage[key]?.let { parseRawList(it, key, "input") }
+            val value = when {
+                fromStorage != null -> fromStorage
+                dataset.input != null -> {
+                    servedFromDb.add(key)
+                    dataset.input!!
+                }
+
+                else -> {
+                    missing.add(key)
+                    emptyList()
+                }
+            }
+            key to value
         }
 
-        return if (rawDatasetsFromStorage.isNotEmpty()) {
-            rawDatasetsFromStorage.mapValues { (_, value) ->
-                val type = object : TypeToken<List<Any>>() {}.type
-                val input: List<Any> = Gson().fromJson(value.decodeToString(), type)
-                input
-            }
-        } else {
-            return datasets.associateBy({ it.id.toString() }, { it.input!! })
-        }
+        logBatchFallbacks("input", datasets.size, servedFromDb, missing)
+        return inputs
     }
 
 
     fun readRawDatasetResults(datasets: List<Dataset>): Map<String, List<Any>?> {
-        var rawDatasetsFromStorage = mutableMapOf<String, ByteArray>()
-        try {
-            rawDatasetsFromStorage =
-                this.storage.getObjects(awsS3Config.datasetsBucketName, datasets.map { "${it.id.toString()}/result" })
-                    .mapKeys { it.key.substringBefore("/") }.toMutableMap()
-        } catch (e: Exception) {
-            logger.warn(e) { "Failed to read datasets" }
+        val rawDatasetsFromStorage = readRawObjectsFromStorage(datasets, "result")
+
+        val servedFromDb = mutableListOf<String>()
+
+        val results = datasets.associateTo(LinkedHashMap<String, List<Any>?>()) { dataset ->
+            val key = dataset.id.toString()
+            val fromStorage = rawDatasetsFromStorage[key]?.let { parseRawList(it, key, "result") }
+            val value: List<Any>? = when {
+                fromStorage != null -> fromStorage
+                dataset.result != null -> {
+                    servedFromDb.add(key)
+                    dataset.result
+                }
+                // A null result is a legitimate state (e.g. prediction not finished), so do not warn.
+                else -> null
+            }
+            key to value
         }
 
-        return if (rawDatasetsFromStorage.isNotEmpty()) {
-            rawDatasetsFromStorage.mapValues { (_, value) ->
-                val type = object : TypeToken<List<Any>>() {}.type
-                val result: List<Any> = Gson().fromJson(value.decodeToString(), type)
-                result
+        logBatchFallbacks("result", datasets.size, servedFromDb, emptyList())
+        return results
+    }
+
+    /**
+     * Batch-reads the given [suffix] (`input`/`result`) objects for [datasets] from storage, keyed by
+     * dataset id. A storage failure is logged and treated as "nothing found" so callers fall back to
+     * the database per row instead of failing the whole batch.
+     */
+    private fun readRawObjectsFromStorage(datasets: List<Dataset>, suffix: String): Map<String, ByteArray> {
+        if (datasets.isEmpty()) {
+            return emptyMap()
+        }
+        return try {
+            this.storage.getObjects(awsS3Config.datasetsBucketName, datasets.map { "${it.id.toString()}/$suffix" })
+                .mapKeys { it.key.substringBefore("/") }
+        } catch (e: Exception) {
+            logger.warn(e) {
+                "Failed to batch read dataset ${suffix}s from storage for ${datasets.size} dataset(s); " +
+                    "falling back to database per row"
             }
-        } else {
-            return datasets.associateBy({ it.id.toString() }, { it.result })
+            emptyMap()
         }
     }
+
+    private fun parseRawList(raw: ByteArray, datasetId: String, suffix: String): List<Any>? {
+        return try {
+            val type = object : TypeToken<List<Any>>() {}.type
+            Gson().fromJson(raw.decodeToString(), type)
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to parse stored $suffix for dataset $datasetId; falling back to database" }
+            null
+        }
+    }
+
+    private fun logBatchFallbacks(
+        suffix: String,
+        total: Int,
+        servedFromDb: List<String>,
+        missing: List<String>
+    ) {
+        if (servedFromDb.isEmpty() && missing.isEmpty()) {
+            return
+        }
+        logger.warn {
+            "Dataset $suffix not found in storage for ${servedFromDb.size + missing.size}/$total dataset(s). " +
+                "Served from database: $servedFromDb. Missing in both storage and database: $missing."
+        }
+    }
+
 
     fun readRawDatasetInput(dataset: Dataset): List<Any> {
         var rawDatasetFromStorage = Optional.empty<ByteArray>()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,8 @@ spring:
   docker:
     compose:
       lifecycle-management: none
+  lifecycle:
+    timeout-per-shutdown-phase: 60s
 #  cache:
 #    type: none
 
@@ -69,6 +71,7 @@ aws:
     images-distribution-url:
 
 server:
+  shutdown: graceful
   error:
     include-message: always
     include-binding-errors: always


### PR DESCRIPTION
## Summary
Dataset offloading to object storage silently stopped working: affected datasets kept their `input` in Postgres, no S3 object was ever written, and no error was logged. Reads then fell back to the database, and the buggy batch-read path showed empty input for some rows. Restarting the service temporarily "fixed" it.

## Root cause
`QSARToolboxAPI` (and `KeycloakTokenExchanger`) used a bare `RestTemplate`, which has no connect/read timeouts. When the QSAR Toolbox backend started hanging, those calls — executed on the shared Spring `@Async` pool — blocked forever and pinned every worker thread. The pool's unbounded queue then silently accumulated every subsequent dataset-offload task, so `storeRawDataset()` was never called. A restart clears the saturated pool, which is why restarting appeared to fix it (until it recurred).

## Changes
### Root-cause fixes
- Add a shared `RestTemplate` bean with bounded connect (10s) / read (60s) timeouts (`RestTemplateConfig`) and use it in `QSARToolboxAPI` and `KeycloakTokenExchanger`, so a hung downstream call can no longer pin async threads indefinitely.
- Replace the default unbounded `@Async` executor with a bounded `ThreadPoolTaskExecutor` (`AsyncConfig`): `CallerRunsPolicy` applies backpressure instead of silently dropping offload tasks, in-flight tasks are drained on shutdown, and previously-swallowed async exceptions are now logged. Named `applicationTaskExecutor` so Micrometer auto-instruments it.
- Enable graceful shutdown (`server.shutdown: graceful` + `spring.lifecycle.timeout-per-shutdown-phase`) so the executor drain runs on deploy/restart.

### Read-side fix
- Rewrite the batch dataset read (`StorageService.readRawDatasetInputs` / `readRawDatasetResults`) to merge per row (storage -> database -> empty) so a partial storage hit no longer drops rows or throws NPE; surface DB fallbacks in logs.

### Self-healing
- Add a `@Scheduled` reconciliation job (`DatasetService`) that re-offloads datasets whose input was persisted to the database but never written to storage (batch of 200, only rows older than 15 min), backed by a new `findDatasetsWithInputNotOffloaded` repository query.

## Testing
Not compiled in this environment (no JDK available). Please run `./gradlew build` on JDK 21 before merging.